### PR TITLE
libpng fixes for M1 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,11 @@ endif()
 if(MSYS)
   set(CMAKE_EXE_LINKER_FLAGS "-static -mwindows")
 endif()
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm64" AND APPLE)
+	set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" )
+elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64" AND APPLE)
+	set( CMAKE_CXX_FLAGS NOT_APPLE_SILICON "${CMAKE_CXX_FLAGS}" )
+endif()
 
 if(WIN32 OR MSYS)
 add_executable(

--- a/source_files/libpng/arm/arm_init.c
+++ b/source_files/libpng/arm/arm_init.c
@@ -10,6 +10,8 @@
  * and license in png.h
  */
 
+#if defined NOT_APPLE_SILICON
+
 /* Below, after checking __linux__, various non-C90 POSIX 1003.1 functions are
  * called.
  */
@@ -134,3 +136,4 @@ png_init_filter_functions_neon(png_structp pp, unsigned int bpp)
 }
 #endif /* PNG_ARM_NEON_OPT > 0 */
 #endif /* READ */
+#endif /* NOT_APPLE_SILICON */

--- a/source_files/libpng/pngrutil.c
+++ b/source_files/libpng/pngrutil.c
@@ -4114,6 +4114,7 @@ png_init_filter_functions(png_structrp pp)
       pp->read_filter[PNG_FILTER_VALUE_PAETH-1] =
          png_read_filter_row_paeth_multibyte_pixel;
 
+#if defined NOT_APPLE_SILICON
 #ifdef PNG_FILTER_OPTIMIZATIONS
    /* To use this define PNG_FILTER_OPTIMIZATIONS as the name of a function to
     * call to install hardware optimizations for the above functions; simply
@@ -4124,6 +4125,7 @@ png_init_filter_functions(png_structrp pp)
     * --enable-arm-neon is specified on the command line.
     */
    PNG_FILTER_OPTIMIZATIONS(pp, bpp);
+#endif
 #endif
 }
 


### PR DESCRIPTION
Apple Silicon fixes for libpng.

Since M1 ARM chips are a bit special (they are neither cortex, armv etc..) they use neon a bit differently than libpng currently allows (it only seems to support arm chips on Linux/Windows rather than M1 Macs).  The CMakeFiles adds a definition on Apple Silicon computers so it will bypass the offending code, on Intel Macs, it will execute normally.