### PR TITLE
Add warning for weapons with no sprites

### DIFF
--- a/source_files/edge/p_user.cc
+++ b/source_files/edge/p_user.cc
@@ -965,7 +965,10 @@ bool P_AddWeapon(player_t *player, weapondef_c *info, int *index)
 
 	// cannot own weapons if sprites are missing
 	if (! P_CheckWeaponSprite(info))
+	{
+		I_Warning("WEAPON %s has no sprites and will not be added!\n", info->name);
 		return false;
+	}
 
 	for (int i=0; i < MAXWEAPONS; i++)
 	{


### PR DESCRIPTION
We need at least 1 sprite in a weapons states, even if it's an invisible dummy png.
Unfortunately up to now EDGE gave the user no clue why certain weapons could never be selected.