### PR TITLE
Hack for incorrect sprite naming

### DIFF
--- a/source_files/edge/w_sprite.cc
+++ b/source_files/edge/w_sprite.cc
@@ -404,8 +404,14 @@ static void MarkCompletedFrames(void)
 			finish_num++;
 
 			if (rot_count < frame->rots)
+			{
 				I_Warning("Sprite %s:%c is missing rotations (%d of %d).\n",
 					def->name, frame_ch, frame->rots - rot_count, frame->rots);
+					
+				//try to fix cases where some dumbass used A1 instead of A0
+				if (rot_count == 1) 
+					frame->rots = 1;	
+			}
 		}
 
 		// remove complete sprites from sprite_map


### PR DESCRIPTION
Try to fix cases where some dumbass used A1 instead of A0 for a sprite with no rotations