### PR TITLE
New levels.ddf commands

### DIFF
--- a/source_files/ddf/level.cc
+++ b/source_files/ddf/level.cc
@@ -81,6 +81,8 @@ static const commandlist_t level_commands[] =
 	DF("PARTIME", partime, DDF_MainGetTime),
 	DF("EPISODE", episode_name, DDF_MainGetString),
 	DF("STATS", wistyle, DDF_LevelGetWistyle),
+	DF("LEAVING_BACKGROUND", leavingbggraphic, DDF_MainGetLumpName),
+	DF("ENTERING_BACKGROUND", enteringbggraphic, DDF_MainGetLumpName),
 
 	DDF_CMD_END
 };
@@ -441,6 +443,8 @@ void mapdef_c::CopyDetail(mapdef_c &src)
 	autotag = src.autotag;
 
 	wistyle = src.wistyle;
+	leavingbggraphic = src.leavingbggraphic;
+	enteringbggraphic = src.enteringbggraphic;
 
 	f_pre = src.f_pre;
 	f_end = src.f_end;
@@ -469,6 +473,9 @@ void mapdef_c::Default()
 	autotag = 0;
 
 	wistyle = WISTYLE_Doom;
+
+	leavingbggraphic.clear();
+	enteringbggraphic.clear();
 
 	f_pre.Default();
 	f_end.Default();

--- a/source_files/ddf/level.h
+++ b/source_files/ddf/level.h
@@ -132,6 +132,8 @@ public:
 	epi::strent_c description;
   
   	lumpname_c namegraphic;
+	lumpname_c leavingbggraphic;
+	lumpname_c enteringbggraphic;
   	lumpname_c lump;
    	lumpname_c sky;
    	lumpname_c surround;

--- a/source_files/edge/f_interm.cc
+++ b/source_files/edge/f_interm.cc
@@ -137,6 +137,8 @@ static style_c *wi_net_style;
 
 // background
 static const image_c *bg_image;
+static const image_c *leaving_bg_image;
+static const image_c *entering_bg_image;
 
 // You Are Here graphic
 static const image_c *yah[2] = {NULL, NULL};
@@ -410,6 +412,12 @@ static void DrawLevelFinished(void)
 	// draw <LevelName> 
 	SYS_ASSERT(lnames[0]);
 
+	//Lobo 2022: if we have a per level image defined, use that instead
+	if (leaving_bg_image)
+	{
+		HUD_DrawImageTitleWS(leaving_bg_image); //Lobo: Widescreen support
+	}
+
 	//float w = IM_WIDTH(lnames[0]); // Seems to be unneeded for now - Dasho
 	//float h = IM_HEIGHT(lnames[0]);
 
@@ -448,6 +456,13 @@ static void DrawEnteringLevel(void)
 	//      (Stop Map30 from crashing)
 	if (! lnames[1])
 		return;
+
+	//Lobo 2022: if we have a per level image defined, use that instead
+	if (entering_bg_image)
+	{
+		HUD_DrawImageTitleWS(entering_bg_image); //Lobo: Widescreen support
+	}
+		
 
 	float h = IM_HEIGHT(entering);
 	//float w = IM_WIDTH(entering); // Seems to be unneeded for now - Dasho
@@ -1440,7 +1455,7 @@ void WI_Drawer(void)
 	{
 		//HUD_StretchImage(0, 0, 320, 200, bg_image);
 		HUD_DrawImageTitleWS(bg_image); //Lobo: Widescreen support
-		
+
 		for (int i = 0; i < worldint.numanims; i++)
 		{
 			wi_anim_c *a = &worldint.anims[i];
@@ -1508,7 +1523,12 @@ static void LoadData(void)
 
 	const gamedef_c *gd = wi_stats.cur->episode;
 
-	// background
+	
+	
+
+	//Lobo 2022: if we have a per level image defined, use that instead
+	leaving_bg_image = W_ImageLookup(wi_stats.cur->leavingbggraphic);
+	entering_bg_image = W_ImageLookup(wi_stats.cur->enteringbggraphic);
 	bg_image = W_ImageLookup(gd->background);
 
 	lnames[0] = W_ImageLookup(wi_stats.cur->namegraphic);


### PR DESCRIPTION
LEAVING_BACKGROUND and
ENTERING_BACKGROUND which can be used to override the intermission background defined in games.ddf on a per level basis.