### PR TITLE
NO_TRIGGER_LINES special for things.ddf

### DIFF
--- a/source_files/ddf/thing.cc
+++ b/source_files/ddf/thing.cc
@@ -1454,6 +1454,7 @@ static specflags_t hyper_specials[] =
 	{"TILT", HF_TILT, 0},
 	{"IMMORTAL", HF_IMMORTAL, 0},
 	{"FLOOR_CLIP", HF_FLOORCLIP, 0}, //Lobo: new FLOOR_CLIP flag
+	{"TRIGGER_LINES", HF_NOTRIGGERLINES, 1},
 	{NULL, 0, 0}
 };
 

--- a/source_files/ddf/thing.h
+++ b/source_files/ddf/thing.h
@@ -299,6 +299,9 @@ typedef enum
 	
 	// -Lobo- 2021/11/18: floorclip flag
 	HF_FLOORCLIP = (1 << 17),
+
+	// -Lobo- 2022/05/30: this thing cannot trigger lines
+	HF_NOTRIGGERLINES = (1 << 18),
 	
 }
 mobjhyperflag_t;

--- a/source_files/edge/p_spec.cc
+++ b/source_files/edge/p_spec.cc
@@ -1094,6 +1094,10 @@ static bool P_ActivateSpecialLine(line_t * line,
 			// Monsters don't trigger secrets
 			if (line && (line->flags & MLF_Secret))
 				return false;
+
+			// Monster is not allowed to trigger lines
+			if (thing->info->hyperflags & HF_NOTRIGGERLINES)
+				return false;
 		}
 		else
 		{


### PR DESCRIPTION
Similar to the same in attacks.ddf. 
Monsters flagged with this special cannot activate special lines i.e. doors etc.