### PR TITLE
Weapons.ddf: BECOME() Action. RTS: REPLACE_WEAPON and WEAPON_EVENT commands

### DIFF
--- a/source_files/ddf/local.h
+++ b/source_files/ddf/local.h
@@ -329,6 +329,7 @@ void DDF_StateGetFloat (const char *arg, state_t * cur_state);
 void DDF_StateGetPercent (const char *arg, state_t * cur_state);
 void DDF_StateGetJump (const char *arg, state_t * cur_state);
 void DDF_StateGetBecome(const char *arg, state_t * cur_state);
+void DDF_StateGetBecomeWeapon(const char *arg, state_t * cur_state);
 void DDF_StateGetFrame (const char *arg, state_t * cur_state);
 void DDF_StateGetAngle (const char *arg, state_t * cur_state);
 void DDF_StateGetSlope (const char *arg, state_t * cur_state);

--- a/source_files/ddf/main.h
+++ b/source_files/ddf/main.h
@@ -95,6 +95,20 @@ public:
 }
 act_become_info_t;
 
+// Info for the weapon BECOME action
+typedef struct wep_become_info_s
+{
+	const weapondef_c *info;
+	epi::strent_c info_ref;
+
+	label_offset_c start;
+
+public:
+	 wep_become_info_s();
+	~wep_become_info_s();
+}
+wep_become_info_t;
+
 
 // ------------------------------------------------------------------
 // -------------------------EXTERNALISATIONS-------------------------

--- a/source_files/ddf/states.cc
+++ b/source_files/ddf/states.cc
@@ -906,6 +906,75 @@ void DDF_StateGetBecome(const char *arg, state_t * cur_state)
 }
 
 
+wep_become_info_s::wep_become_info_s() :
+	info(NULL), info_ref(), start()
+{ }
+
+wep_become_info_s::~wep_become_info_s()
+{ }
+
+void DDF_StateGetBecomeWeapon(const char *arg, state_t * cur_state)
+{
+	// BECOME(typename)
+	// BECOME(typename,label)
+  
+	if (!arg || !arg[0])
+		return;
+
+	wep_become_info_t *become = new wep_become_info_t;
+
+	become->start.label.Set("READY");
+
+	const char *s = strchr(arg, ',');
+
+	// get type name
+	char buffer[80];
+
+	int len = s ? (s - arg) : strlen(arg);
+
+	if (len == 0)
+		DDF_Error("DDF_StateGetBecomeWeapon: missing type name!\n");
+
+	if (len > 75)
+		DDF_Error("DDF_StateGetBecomeWeapon: type name too long!\n");
+
+	for (len=0; *arg && (*arg != ':') && (*arg != ','); len++, arg++)
+		buffer[len] = *arg;
+
+	buffer[len] = 0;
+
+	become->info_ref.Set(buffer);
+
+	
+	// get start label (if present)
+	if (s)
+	{
+		s++;
+
+		len = strlen(s);
+
+		if (len == 0)
+			DDF_Error("DDF_StateGetBecomeWeapon: missing label!\n");
+
+		if (len > 75)
+			DDF_Error("DDF_StateGetBecomeWeapon: label too long!\n");
+
+		for (len=0; *s && (*s != ':') && (*s != ','); len++, s++)
+			buffer[len] = *s;
+
+		buffer[len] = 0;
+
+		become->start.label.Set(buffer);
+
+		if (*s == ':')
+			become->start.offset = MAX(0, atoi(s+1) - 1);
+
+	}
+
+	cur_state->action_par = become;
+}
+
+
 void DDF_StateGetAngle(const char *arg, state_t * cur_state)
 {
 	angle_t *value;

--- a/source_files/ddf/weapon.cc
+++ b/source_files/ddf/weapon.cc
@@ -174,6 +174,8 @@ static const actioncode_t weapon_actions[] =
 	{"SOUND2",           A_SFXWeapon2, NULL},
 	{"SOUND3",           A_SFXWeapon3, NULL},
 
+	{"BECOME",            A_WeaponBecome, DDF_StateGetBecomeWeapon},
+
 	{NULL, NULL, NULL}
 };
 

--- a/source_files/edge/rad_act.h
+++ b/source_files/edge/rad_act.h
@@ -59,6 +59,8 @@ void RAD_ActWaitUntilDead(rad_trigger_t *R, void *param);
 
 void RAD_ActSwitchWeapon(rad_trigger_t *R, void *param);
 void RAD_ActTeleportToStart(rad_trigger_t *R, void *param);
+void RAD_ActReplaceWeapon(rad_trigger_t *R, void *param);
+void RAD_ActWeaponEvent(rad_trigger_t *R, void *param);
 
 
 #endif  /*__RAD_ACT_H__*/

--- a/source_files/edge/rad_defs.h
+++ b/source_files/edge/rad_defs.h
@@ -389,6 +389,25 @@ typedef struct s_thing_event_s
 }
 s_thing_event_t;
 
+// Weapon Event
+typedef struct s_weapon_event_s
+{
+	// DDF type name of weapon to cause the event. 
+	const char *weapon_name;
+
+	// label to jump to
+	const char *label;
+	int offset;
+}
+s_weapon_event_t;
+
+typedef struct s_weapon_replace_s
+{
+	const char *old_weapon;
+	const char *new_weapon;
+}
+s_weapon_replace_t;
+
 
 // A single RTS action, not unlike the ones for DDF things.
 //


### PR DESCRIPTION
-BECOME(): Similar to the things.ddf action fo the same name.

-REPLACE_WEAPON <OldWeaponName> <NewWeaponName>
Replace one weapon with another instantly (no up/down states run). It doesnt matter if we have the old one currently selected or not.

-WEAPON_EVENT <weapon> <label>
Similar to THING_EVENT: If we have the weapon we insta-switch to it and go to the STATE we indicated.