### PR TITLE
SKYTRANSFER null check

### DIFF
--- a/source_files/edge/p_spec.cc
+++ b/source_files/edge/p_spec.cc
@@ -636,7 +636,8 @@ static void P_LineEffect(line_t *target, line_t *source,
 	//Lobo 2022: experimental partial sky transfer support
 	if ((special->line_effect & LINEFX_SkyTransfer) && source->side[0])
 	{
-		sky_image = W_ImageLookup(source->side[0]->top.image->name, INS_Texture);
+		if(source->side[0]->top.image)
+			sky_image = W_ImageLookup(source->side[0]->top.image->name, INS_Texture);
 	}
 }
 


### PR DESCRIPTION
Boaty MacBoatwad map07 has an erroneous skytransfer