### PR TITLE
Add a default SECRET sfx

### DIFF
--- a/source_files/ddf/thing.cc
+++ b/source_files/ddf/thing.cc
@@ -2407,7 +2407,8 @@ void mobjtype_c::Default()
 	noway_sound = sfx_None;
 	oof_sound = sfx_None;
 	gasp_sound = sfx_None;
-	secretsound = sfx_None;
+	//secretsound = sfx_None;
+	secretsound = sfxdefs.GetEffect("SECRET");
 	falling_sound = sfx_None;
 
     fuse = 0;


### PR DESCRIPTION
Mods that do not have the SECRET_SOUND set in OUR_HERO things.ddf(old mods) would not play the sfx on finding a secret.