### PR TITLE
check first for bytes to detect MIDI

### DIFF
--- a/source_files/edge/s_music.cc
+++ b/source_files/edge/s_music.cc
@@ -211,9 +211,9 @@ void S_ChangeMusic(int entrynum, bool loop)
 		music_player = S_PlaySIDMusic(play, volume, loop);
 		return;
 	}
-	
+
 	bool is_mus  = (data[0] == 'M' && data[1] == 'U' && data[2] == 'S');
-	bool is_midi = (data[14] == 'M' && data[15] == 'T' && data[16] == 'r' && data[17] == 'k'); // First track chunk location (I think) - Dasho
+	bool is_midi = (data[0] == 'M' && data[1] == 'T' && data[2] == 'h' && data[3] == 'd');
 
 	if (! (is_mus || is_midi))
 	{

--- a/source_files/opl/midifile.cc
+++ b/source_files/opl/midifile.cc
@@ -107,7 +107,7 @@ typedef struct
 {
     uint8_t *start;
     uint8_t *pos;
-    ssize_t  len;
+    size_t   len;
 } input_stream_t;
 
 // Check the header of a chunk:
@@ -437,8 +437,8 @@ static bool ReadTrackHeader(midi_track_t *track, input_stream_t *stream)
 {
     chunk_header_t chunk_header;
 
-    ssize_t position  = (ssize_t)(stream->pos - stream->start);
-    ssize_t remaining = stream->len - position;
+    size_t position  = (size_t)(stream->pos - stream->start);
+    size_t remaining = stream->len - position;
 
     if (position + sizeof(chunk_header_t) > stream->len)
     {
@@ -581,8 +581,8 @@ static bool ReadFileHeader(midi_file_t *file, input_stream_t *stream)
 {
     unsigned int format_type;
 
-    ssize_t position  = (ssize_t)(stream->pos - stream->start);
-    ssize_t remaining = stream->len - position;
+    size_t position  = (size_t)(stream->pos - stream->start);
+    size_t remaining = stream->len - position;
 
     if (position + sizeof(midi_header_t) > stream->len)
     {
@@ -631,7 +631,7 @@ void MIDI_FreeFile(midi_file_t *file)
     free(file);
 }
 
-midi_file_t *MIDI_LoadFile(uint8_t *input, ssize_t length)
+midi_file_t *MIDI_LoadFile(uint8_t *input, size_t length)
 {
     input_stream_t stream;
 

--- a/source_files/opl/midifile.h
+++ b/source_files/opl/midifile.h
@@ -21,11 +21,6 @@
 
 #include <inttypes.h>
 
-// Not sure if signed int is the exact best MSVC equivalent for ssize_t, will do more research - Dasho
-#ifdef _MSC_VER
-#define ssize_t signed int
-#endif
-
 typedef struct midi_file_s midi_file_t;
 
 #define MIDI_CHANNELS_PER_TRACK 16
@@ -134,7 +129,7 @@ typedef struct midi_event_s
 
 // Load a MIDI file.
 
-midi_file_t *MIDI_LoadFile(uint8_t *input, ssize_t length);
+midi_file_t *MIDI_LoadFile(uint8_t *input, size_t length);
 
 // Free a MIDI file.
 


### PR DESCRIPTION
I mucked up the previous check, apologies for that, MIDI files have a"MThd" magic at the very beginning and that's the more standard way to check.

This PR also replaces the "ssize_t" in the OPL midi loader with "size_t" type.  I will keep in mind that Microsoft compilers don't know about "ssize_t".

I tested these changes and both seem good.