### PR TITLE
removed `-ecompat` cmdline option, disabled BOOM_COMPAT level flag.

### DIFF
--- a/source_files/ddf/level.cc
+++ b/source_files/ddf/level.cc
@@ -115,7 +115,7 @@ static specflags_t map_specials[] =
     {"HALOS", MPF_Halos, 0},
     {"CROUCHING", MPF_Crouching, 0},
     {"WEAPON_KICK", MPF_Kicking, 0},
-    {"BOOM_COMPAT", MPF_BoomCompat, 0},
+    {"BOOM_COMPAT", MPF_BoomCompat, 0},  // old flag, does nothing anymore
 
     {NULL, 0, 0}
 };
@@ -297,7 +297,7 @@ void DDF_LevelGetSpecials(const char *info)
 
 		case CHKF_Negative:
 			dynamic_level->force_on  &= ~flag_value;
-			dynamic_level->force_off |= flag_value;
+			dynamic_level->force_off |=  flag_value;
 			break;
 
 		case CHKF_User:

--- a/source_files/ddf/level.h
+++ b/source_files/ddf/level.h
@@ -75,27 +75,26 @@ typedef enum
 	MPF_Mlook         = (1 << 1),
 	MPF_Cheats        = (1 << 3),
 	MPF_ItemRespawn   = (1 << 4),
-	MPF_FastParm      = (1 << 5),     // Fast Monsters
-	MPF_ResRespawn    = (1 << 6),     // Resurrect Monsters (else Teleport)
+	MPF_FastParm      = (1 << 5),   // Fast Monsters
+	MPF_ResRespawn    = (1 << 6),   // Resurrect Monsters (else Teleport)
 	MPF_StretchSky    = (1 << 7),
 
-	MPF_True3D        = (1 << 8),    // True 3D Gameplay
-	MPF_Stomp         = (1 << 9),    // Monsters can stomp players
-	MPF_MoreBlood     = (1 << 10),    // Make a bloody mess
+	MPF_True3D        = (1 << 8),   // True 3D Gameplay
+	MPF_Stomp         = (1 << 9),   // Monsters can stomp players
+	MPF_MoreBlood     = (1 << 10),  // Make a bloody mess
 	MPF_Respawn       = (1 << 11),
 	MPF_AutoAim       = (1 << 12),
 	MPF_AutoAimMlook  = (1 << 13),
-	MPF_ResetPlayer   = (1 << 14),   // Force player back to square #1
+	MPF_ResetPlayer   = (1 << 14),  // Force player back to square #1
 	MPF_Extras        = (1 << 15),
 
 	MPF_LimitZoom     = (1 << 16),  // Limit zoom to certain weapons
 	MPF_Shadows       = (1 << 17),
 	MPF_Halos         = (1 << 18),
 	MPF_Crouching     = (1 << 19),
-	MPF_Kicking       = (1 << 20), // Weapon recoil
-	MPF_BoomCompat    = (1 << 21),
+	MPF_Kicking       = (1 << 20),  // Weapon recoil
+	MPF_BoomCompat    = (1 << 21),  // old flag, does nothing anymore
 	MPF_WeaponSwitch  = (1 << 22),
-	MPF_NoMonsters    = (1 << 23), // (Only for demos!)
 
 	MPF_PassMissile   = (1 << 24),
 	MPF_TeamDamage    = (1 << 25),

--- a/source_files/ddf/line.cc
+++ b/source_files/ddf/line.cc
@@ -581,13 +581,6 @@ void DDF_LineGetTrigType(const char *info, void *storage)
 	{
 		if (DDF_CompareName(info, s_trigger[i].s) == 0)
 		{
-#if 0  // DISABLED FOR NOW
-			if (global_flags.edge_compat && (trigger_e)s_trigger[i].n == line_manual)
-			{
-				*var = line_pushable;
-				return;
-			}
-#endif
 			*var = (trigger_e)s_trigger[i].n;
 			return;
 		}

--- a/source_files/edge/dm_defs.h
+++ b/source_files/edge/dm_defs.h
@@ -119,7 +119,6 @@ typedef struct gameflags_s
 	bool have_extra;
 	bool limit_zoom;
 
-	bool edge_compat;
 	bool kicking;
 	bool weapon_switch;
 	bool pass_missile;

--- a/source_files/edge/e_main.cc
+++ b/source_files/edge/e_main.cc
@@ -168,7 +168,6 @@ gameflags_t default_gameflags =
 	true,   // have_extra
 	false,  // limit_zoom
 
-	false,    // edge_compat
 	true,     // kicking
 	true,     // weapon_switch
 	true,     // pass_missile
@@ -371,9 +370,6 @@ static void SetGlobalVars(void)
 		use_dlights = 1;
 	else if (M_CheckParm("-nodlights"))
 		use_dlights = 0;
-
-	if (M_CheckParm("-ecompat"))
-		global_flags.edge_compat = true;
 
 	if (!global_flags.respawn)
 	{

--- a/source_files/edge/g_game.cc
+++ b/source_files/edge/g_game.cc
@@ -197,11 +197,6 @@ void LoadLevel_Bits(void)
 
 #undef HANDLE_FLAG
 
-	if (currmap->force_on & MPF_BoomCompat)
-		level_flags.edge_compat = false;
-	else if (currmap->force_off & MPF_BoomCompat)
-		level_flags.edge_compat = true;
-
 	if (currmap->force_on & MPF_AutoAim)
 	{
 		if (currmap->force_on & MPF_AutoAimMlook)
@@ -806,8 +801,7 @@ static bool G_LoadGameFromFile(const char *filename, bool is_hub)
 	if (globs->sky_image)  // backwards compat (sky_image added 2003/12/19)
 		sky_image = globs->sky_image;
 
-	// clear line/sector lookup caches, in case level_flags.edge_compat
-	// has changed.
+	// clear line/sector lookup caches
 	DDF_BoomClearGenTypes();
 
 	if (SV_LoadEverything() && SV_GetError() == 0)

--- a/source_files/edge/p_setup.cc
+++ b/source_files/edge/p_setup.cc
@@ -3125,13 +3125,6 @@ sectortype_c *P_LookupSectorType(int num)
 	if (def)
 		return def;
 
-	if (level_flags.edge_compat && (num > 0) && (num < 100))
-	{
-		sectortype_c* def = sectortypes.Lookup(4400 + num);
-		if (def)
-			return def;
-	}
-
 	if (DDF_IsBoomSectorType(num))
 		return DDF_BoomGetGenSector(num);
 

--- a/source_files/edge/sv_glob.cc
+++ b/source_files/edge/sv_glob.cc
@@ -179,8 +179,6 @@ static void GV_GetLevelFlags(const char *info, void *storage)
 
 #undef HANDLE_FLAG
 
-	dest->edge_compat = (flags & MPF_BoomCompat) ? false : true;
-
 	dest->autoaim = (flags & MPF_AutoAim) ? 
 		((flags & MPF_AutoAimMlook) ? AA_MLOOK : AA_ON) : AA_OFF;
 }
@@ -277,9 +275,6 @@ static const char *GV_PutLevelFlags(void *storage)
 	HANDLE_FLAG(src->team_damage, MPF_TeamDamage);
 
 #undef HANDLE_FLAG
-
-	if (!src->edge_compat)
-		flags |= MPF_BoomCompat;
 
 	if (src->autoaim != AA_OFF)
 		flags |= MPF_AutoAim;


### PR DESCRIPTION
These do almost nothing nowadays, the only remaining effect is a translation of unknown sector specials in the range 0-99 to the range 4400-4499, which was needed by some ancient EDGE mods (way back in the mists of time).