### PR TITLE
load the COALAPI lump from "edge-defs.wad" only, not other wads.

### DIFF
--- a/source_files/edge/w_wad.cc
+++ b/source_files/edge/w_wad.cc
@@ -1562,11 +1562,13 @@ void W_ReadCoalLumps(void)
 		data_file_c *df = data_files[f];
 		wad_file_c *wad = df->wad;
 
-		// FIXME support PK3
+		// FIXME support PK3 for coal_huds
 
 		if (wad != NULL)
 		{
-			if (wad->coal_apis >= 0)
+			// only load COALAPI from edge-defs, because (like WADFIXES)
+			// it is not something that user mods should mess with.
+			if (wad->coal_apis >= 0 && f == 0)
 				VM_LoadLumpOfCoal(wad->coal_apis);
 
 			if (wad->coal_huds >= 0)


### PR DESCRIPTION
Rationale : This lump provides the API to the engine, it is not something
that mods should mess with, or gives them any superpowers, and we want the
freedom to change how something is implemented without worrying about mods
which contain an out-of-date COALAPI lump.