### PR TITLE
support `flags` parameter for hud.render_world() and hud.render_automap().

### DIFF
--- a/source_files/edge/f_interm.cc
+++ b/source_files/edge/f_interm.cc
@@ -1538,7 +1538,7 @@ void WI_Drawer(void)
 
 	if (background_camera_mo)
 	{
-		HUD_RenderWorld(0, 0, 320, 200, background_camera_mo);
+		HUD_RenderWorld(0, 0, 320, 200, background_camera_mo, 0);
 	} 
 	else
 	{

--- a/source_files/edge/hu_draw.h
+++ b/source_files/edge/hu_draw.h
@@ -117,7 +117,7 @@ void HUD_DrawChar(float left_x, float top_y, const image_c *img, char ch, float 
 void HUD_DrawText(float x, float y, const char *str, float size = 0);
 
 // render a view of the world using the given camera object.
-void HUD_RenderWorld(float x, float y, float w, float h, mobj_t *camera);
+void HUD_RenderWorld(float x, float y, float w, float h, mobj_t *camera, int flags);
 
 // render the automap
 void HUD_RenderAutomap(float x, float y, float w, float h, mobj_t *focus, int flags);

--- a/source_files/edge/vm_coal.h
+++ b/source_files/edge/vm_coal.h
@@ -22,8 +22,7 @@
 void VM_InitCoal();
 void VM_QuitCoal();
 
-void VM_LoadCoalFire(const char *filename);
-void VM_LoadLumpOfCoal(int lump);
+void VM_AddScript(int type, std::string& data, const std::string& source);
 void VM_LoadScripts();
 
 void VM_RegisterHUD();

--- a/source_files/edge/vm_hud.cc
+++ b/source_files/edge/vm_hud.cc
@@ -519,7 +519,7 @@ static void HD_game_paused(coal::vm_c *vm, int argc)
 	}
 }
 
-// hud.render_world(x, y, w, h)
+// hud.render_world(x, y, w, h, [flags])
 //
 static void HD_render_world(coal::vm_c *vm, int argc)
 {
@@ -528,11 +528,13 @@ static void HD_render_world(coal::vm_c *vm, int argc)
 	float w = *vm->AccessParam(2);
 	float h = *vm->AccessParam(3);
 
-	HUD_RenderWorld(x, y, w, h, ui_hud_who->mo);
+	int flags = (int) *vm->AccessParam(4);
+
+	HUD_RenderWorld(x, y, w, h, ui_hud_who->mo, flags);
 }
 
 
-// hud.render_automap(x, y, w, h)
+// hud.render_automap(x, y, w, h, [flags])
 //
 static void HD_render_automap(coal::vm_c *vm, int argc)
 {
@@ -540,6 +542,8 @@ static void HD_render_automap(coal::vm_c *vm, int argc)
 	float y = *vm->AccessParam(1);
 	float w = *vm->AccessParam(2);
 	float h = *vm->AccessParam(3);
+
+	int flags = (int) *vm->AccessParam(4);
 
 	int   old_state;
 	float old_zoom;
@@ -556,7 +560,7 @@ static void HD_render_automap(coal::vm_c *vm, int argc)
 
 	AM_SetState(new_state, new_zoom);
 
-	HUD_RenderAutomap(x, y, w, h, ui_hud_who->mo, 0);
+	HUD_RenderAutomap(x, y, w, h, ui_hud_who->mo, flags);
 
 	AM_SetState(old_state, old_zoom);
 }

--- a/source_files/edge/vm_hud.cc
+++ b/source_files/edge/vm_hud.cc
@@ -45,7 +45,7 @@
 
 extern coal::vm_c *ui_vm;
 
-extern void VM_SetFloat(coal::vm_c *vm, const char *name, double value);
+extern void VM_SetFloat(coal::vm_c *vm, const char *mod, const char *name, double value);
 extern void VM_CallFunction(coal::vm_c *vm, const char *name);
 
 // Needed for color functions
@@ -102,6 +102,9 @@ static void HD_coord_sys(coal::vm_c *vm, int argc)
 		I_Error("Bad hud.coord_sys size: %dx%d\n", w, h);
 
 	HUD_SetCoordSys(w, h);
+
+	VM_SetFloat(ui_vm, "hud", "x_left",  hud_x_left);
+	VM_SetFloat(ui_vm, "hud", "x_right", hud_x_right);
 }
 
 

--- a/source_files/edge/w_pk3.cc
+++ b/source_files/edge/w_pk3.cc
@@ -19,6 +19,7 @@
 #include "i_defs.h"
 #include "l_deh.h"
 #include "w_files.h"
+#include "vm_coal.h"
 
 // EPI
 #include "epi.h"
@@ -605,6 +606,8 @@ static void ProcessDDFInPack(pack_file_c *pack)
 	data_file_c *df = pack->parent;
 
 	std::string bare_filename = epi::PATH_GetFilename(df->name.c_str());
+	if (bare_filename == "")
+		bare_filename = df->name;
 
 	for (size_t i = 0 ; i < pack->dirs[0].entries.size() ; i++)
 	{
@@ -643,6 +646,34 @@ static void ProcessDDFInPack(pack_file_c *pack)
 			continue;
 		}
 	}
+}
+
+
+static void ProcessCoalInPack(pack_file_c *pack)
+{
+	const char *name = "coal_hud.ec";
+
+	int idx = pack->dirs[0].Find(name);
+	if (idx < 0)
+		return;
+
+	data_file_c *df = pack->parent;
+
+	std::string bare_filename = epi::PATH_GetFilename(df->name.c_str());
+	if (bare_filename == "")
+		bare_filename = df->name;
+
+	std::string source = name;
+	source += " in ";
+	source += bare_filename;
+
+	int length = -1;
+	const byte *raw_data = pack->LoadEntry(0, idx, length);
+
+	std::string data((const char *)raw_data);
+	delete[] raw_data;
+
+	VM_AddScript(0, data, source);
 }
 
 
@@ -904,6 +935,7 @@ void ProcessPackage(data_file_c *df, size_t file_index)
 	ProcessMusicsInPack(df->pack);
 
 	ProcessDDFInPack(df->pack);
+	ProcessCoalInPack(df->pack);
 }
 
 

--- a/source_files/edge/w_wad.cc
+++ b/source_files/edge/w_wad.cc
@@ -1082,6 +1082,42 @@ static void ProcessDDFInWad(data_file_c *df)
 }
 
 
+static void ProcessCoalInWad(data_file_c *df)
+{
+	std::string bare_filename = epi::PATH_GetFilename(df->name.c_str());
+
+	wad_file_c *wad = df->wad;
+
+	// only load COALAPI from edge-defs, because (like WADFIXES)
+	// it is not something that user mods should mess with.
+	if (wad->coal_apis >= 0 && df->kind == FLKIND_EWad)
+	{
+		int lump = wad->coal_apis;
+
+		std::string data   = W_LoadString(lump);
+		std::string source = W_GetLumpName(lump);
+
+		source += " in ";
+		source += bare_filename;
+
+		VM_AddScript(0, data, source);
+	}
+
+	if (wad->coal_huds >= 0)
+	{
+		int lump = wad->coal_huds;
+
+		std::string data   = W_LoadString(lump);
+		std::string source = W_GetLumpName(lump);
+
+		source += " in ";
+		source += bare_filename;
+
+		VM_AddScript(0, data, source);
+	}
+}
+
+
 static void ProcessBoomStuffInWad(data_file_c *df)
 {
 	// handle Boom's ANIMATED and SWITCHES lumps
@@ -1214,6 +1250,7 @@ void ProcessWad(data_file_c *df, size_t file_index)
 	ProcessDehackedInWad(df);
 	ProcessBoomStuffInWad(df);
 	ProcessDDFInWad(df);
+	ProcessCoalInWad(df);
 }
 
 
@@ -1549,29 +1586,6 @@ void W_ReadUMAPINFOLumps(void)
 		if(Maps.maps[i].partime > 0)
 			temp_level->partime = Maps.maps[i].partime;
 		
-	}
-}
-
-
-void W_ReadCoalLumps(void)
-{
-	for (int f = 0; f < (int)data_files.size(); f++)
-	{
-		data_file_c *df = data_files[f];
-		wad_file_c *wad = df->wad;
-
-		// FIXME support PK3 for coal_huds
-
-		if (wad != NULL)
-		{
-			// only load COALAPI from edge-defs, because (like WADFIXES)
-			// it is not something that user mods should mess with.
-			if (wad->coal_apis >= 0 && df->kind == FLKIND_EWad)
-				VM_LoadLumpOfCoal(wad->coal_apis);
-
-			if (wad->coal_huds >= 0)
-				VM_LoadLumpOfCoal(wad->coal_huds);
-		}
 	}
 }
 

--- a/source_files/edge/w_wad.h
+++ b/source_files/edge/w_wad.h
@@ -44,8 +44,6 @@ public:
 	int texture2;
 };
 
-void W_ReadCoalLumps(void);
-
 int W_CheckNumForName(const char *name);
 int W_CheckNumForName_GFX(const char *name);
 int W_GetNumForName(const char *name);


### PR DESCRIPTION
Also mad the default (zero) have behavior compatible with existing COAL huds,which is to extend the area to the full width of the screen when left and right touch edge of virtual 320x200 screen.