### PR TITLE
Bugfix: query_weapon()

### DIFF
--- a/source_files/edge/vm_player.cc
+++ b/source_files/edge/vm_player.cc
@@ -1103,6 +1103,8 @@ std::string GetQueryInfoFromWeapon(mobj_t *obj, int whatinfo, bool secattackinfo
 		return "";
 	if (!obj->info->pickup_benefits->sub.weap)
 		return "";	
+	if (obj->info->pickup_benefits->type != BENEFIT_Weapon)
+		return "";	
 
 	weapondef_c *objWep = obj->info->pickup_benefits->sub.weap;
 	if (!objWep)


### PR DESCRIPTION
For some reason "Shells" seem to return a weapon obj which caused a crash. Now explicitly check it's a BENEFIT_weapon too