### PR TITLE
Bugfix: UMAPINFO

### DIFF
--- a/source_files/ddf/language.cc
+++ b/source_files/ddf/language.cc
@@ -201,10 +201,9 @@ void language_c::AddOrReplace(const char *ref, const char *value)
 {
 	if (umap == NULL)
 	{
-		umap = new lang_choice_c;
-
-		umap->AddEntry(ref, value);
+		umap = new lang_choice_c;	
 	}
+	umap->AddEntry(ref, value);
 }
 
 


### PR DESCRIPTION
At some stage AddOrReplace was changed so that it only ever stored 1 single language ref.